### PR TITLE
Add GitHub Actions configuration file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-latest] #, macos-latest, windows-latest]
+        perl: [ '5.36' ]
+
+    runs-on: ${{matrix.runner}}
+    name: OS ${{matrix.runner}} Perl ${{matrix.perl}}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up perl
+      uses: shogo82148/actions-setup-perl@v1
+      with:
+          perl-version: ${{ matrix.perl }}
+          distribution: ${{ ( startsWith( matrix.runner, 'windows-' ) && 'strawberry' ) || 'default' }}
+
+    - name: Show Perl Version
+      run: |
+        perl -v
+
+    - name: Install Modules
+      run: |
+        cpanm -v
+        cpanm --installdeps --notest .
+
+    - name: Run tests
+      run: |
+        perl Makefile.PL
+        make
+        make test
+
+    - name: Show Errors on Windows
+      if:  ${{ failure() && startsWith( matrix.runner, 'windows-')}}
+      run: |
+         ls -l C:/Users/
+         ls -l C:/Users/RUNNER~1/
+         cat C:/Users/runneradmin/.cpanm/work/*/build.log
+
+    - name: Show Errors on Ubuntu
+      if:  ${{ failure() && startsWith( matrix.runner, 'ubuntu-')}}
+      run: |
+         cat /home/runner/.cpanm/work/*/build.log
+
+    - name: Show Errors on OSX
+      if:  ${{ failure() && startsWith( matrix.runner, 'macos-')}}
+      run: |
+         cat  /Users/runner/.cpanm/work/*/build.log
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
         runner: [ubuntu-latest, macos-latest, windows-latest]
         perl: [ '5.30', '5.36' ]
         exclude:
-          runner: windows-latest
-          perl: '5.36'
+          - runner: windows-latest
+            perl: '5.36'
 
     runs-on: ${{matrix.runner}}
     name: OS ${{matrix.runner}} Perl ${{matrix.perl}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [ubuntu-latest] #, macos-latest, windows-latest]
-        perl: [ '5.36' ]
+        runner: [ubuntu-latest, macos-latest, windows-latest]
+        perl: [ '5.30', '5.36' ]
 
     runs-on: ${{matrix.runner}}
     name: OS ${{matrix.runner}} Perl ${{matrix.perl}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ jobs:
       matrix:
         runner: [ubuntu-latest, macos-latest, windows-latest]
         perl: [ '5.30', '5.36' ]
+        exclude:
+          runner: windows-latest
+          perl: '5.36'
 
     runs-on: ${{matrix.runner}}
     name: OS ${{matrix.runner}} Perl ${{matrix.perl}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
As mentioned in the Perl Weekly as well, I am on a quest to enable Continuous Integration (CI) and improve testing on all the CPAN modules where the author is interested in it. Having CI configured will provide fast feedback to the author(s) and will reduce the chances of releasing a module that only works on the computer of the developer. Currently GitHub Actions is the most natural CI system for GitHub-based projects. That's why I am sending this PR.

I've enabled several versions of Perl on 3 different platforms. Except 5.36 on Windows as it does not seem to exist.

I have written several blog posts and recorded videos on the subject. You can find them here: https://perlmaven.com/os
If you need further help with the CI system, feel free to ask me.
If you'd like to support my efforts there are several ways to do so https://szabgab.com/support.html